### PR TITLE
feat(isMACAddress.js): allow single hex digits when separator required

### DIFF
--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const macAddress = /^(?:[0-9a-fA-F]{2}([-:\s]))([0-9a-fA-F]{2}\1){4}([0-9a-fA-F]{2})$/;
+const macAddress = /^(?:[0-9a-fA-F]{1,2}([-:\s]))([0-9a-fA-F]{1,2}\1){4}([0-9a-fA-F]{1,2})$/;
 const macAddressNoSeparators = /^([0-9a-fA-F]){12}$/;
 const macAddressWithDots = /^([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})$/;
 


### PR DESCRIPTION
Separators are required for this match, so there is no reason not to allow single hex digits for any octet.

Tested with all allowed separators.